### PR TITLE
fixed refresh token mess

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ JWT_ISSUER=SBay
 JWT_AUDIENCE=SBayClients
 # JWT_SECRET signs access JWTs only. Refresh tokens are opaque random strings
 # stored hashed in Postgres; JWT_REFRESH_TOKEN_DAYS controls their lifetime.
+# 180 days is the intended stay-signed-in default; see README Authentication Security.
 JWT_SECRET=dev_only_change_me_32_bytes_minimum_value
 JWT_EXP_MINUTES=60
 JWT_REFRESH_TOKEN_DAYS=180

--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,11 @@ EMAIL_SMTP_PASSWORD=
 
 JWT_ISSUER=SBay
 JWT_AUDIENCE=SBayClients
+# JWT_SECRET signs access JWTs only. Refresh tokens are opaque random strings
+# stored hashed in Postgres; JWT_REFRESH_TOKEN_DAYS controls their lifetime.
 JWT_SECRET=dev_only_change_me_32_bytes_minimum_value
 JWT_EXP_MINUTES=60
-JWT_REFRESH_TOKEN_DAYS=30
+JWT_REFRESH_TOKEN_DAYS=180
 
 STORAGE_PROVIDER=local
 STORAGE_LOCAL_PATH=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -32,6 +32,7 @@ JWT_ISSUER=SBay
 JWT_AUDIENCE=SBayClients
 # JWT_SECRET signs access JWTs only. Refresh tokens are opaque random strings
 # stored hashed in Postgres; JWT_REFRESH_TOKEN_DAYS controls their lifetime.
+# 180 days is the intended stay-signed-in default; see README Authentication Security.
 JWT_SECRET=replace_with_32_character_minimum_random_secret
 JWT_EXP_MINUTES=60
 JWT_REFRESH_TOKEN_DAYS=180

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -30,9 +30,11 @@ CONNECTION_STRING=Host=postgres;Port=5432;Database=sbay;Username=sbay;Password=r
 
 JWT_ISSUER=SBay
 JWT_AUDIENCE=SBayClients
+# JWT_SECRET signs access JWTs only. Refresh tokens are opaque random strings
+# stored hashed in Postgres; JWT_REFRESH_TOKEN_DAYS controls their lifetime.
 JWT_SECRET=replace_with_32_character_minimum_random_secret
 JWT_EXP_MINUTES=60
-JWT_REFRESH_TOKEN_DAYS=30
+JWT_REFRESH_TOKEN_DAYS=180
 
 UPLOADS_HOST_PATH=/var/sbay/uploads
 STORAGE_LOCAL_PATH=/app/uploads

--- a/.env.production.example
+++ b/.env.production.example
@@ -32,6 +32,7 @@ JWT_ISSUER=SBay
 JWT_AUDIENCE=SBayClients
 # JWT_SECRET signs access JWTs only. Refresh tokens are opaque random strings
 # stored hashed in Postgres; JWT_REFRESH_TOKEN_DAYS controls their lifetime.
+# 180 days is the intended stay-signed-in default; see README Authentication Security.
 JWT_SECRET=replace_with_32_character_minimum_random_secret
 JWT_EXP_MINUTES=60
 JWT_REFRESH_TOKEN_DAYS=180

--- a/.env.production.example
+++ b/.env.production.example
@@ -30,9 +30,11 @@ CONNECTION_STRING=Host=postgres;Port=5432;Database=sbay;Username=sbay;Password=r
 
 JWT_ISSUER=SBay
 JWT_AUDIENCE=SBayClients
+# JWT_SECRET signs access JWTs only. Refresh tokens are opaque random strings
+# stored hashed in Postgres; JWT_REFRESH_TOKEN_DAYS controls their lifetime.
 JWT_SECRET=replace_with_32_character_minimum_random_secret
 JWT_EXP_MINUTES=60
-JWT_REFRESH_TOKEN_DAYS=30
+JWT_REFRESH_TOKEN_DAYS=180
 
 UPLOADS_HOST_PATH=/var/sbay/uploads
 STORAGE_LOCAL_PATH=/app/uploads

--- a/Backend/SBay.Backend.Tests/Authentication/AuthControllerTest.cs
+++ b/Backend/SBay.Backend.Tests/Authentication/AuthControllerTest.cs
@@ -172,6 +172,29 @@ public class AuthControllerTests : IClassFixture<TestWebAppFactory>
     }
 
     [Fact]
+    public async Task ChangePassword_RevokesRefreshTokens()
+    {
+        var password = "Password1!";
+        var newPassword = "NewPassword1!";
+        var (client, auth) = await AuthTestClient.CreateAuthedAsync(_factory, "change-password", password);
+        auth.RefreshToken.Should().NotBeNullOrWhiteSpace();
+
+        var changePassword = await client.PostAsJsonAsync("/api/auth/change-password", new
+        {
+            currentPassword = password,
+            newPassword
+        });
+        changePassword.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var refresh = await client.PostAsJsonAsync("/api/auth/refresh", new { refreshToken = auth.RefreshToken });
+        refresh.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        var login = await _factory.CreateClient().PostAsJsonAsync("/api/auth/login",
+            new LoginRequest(auth.User.Email, newPassword));
+        login.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task Login_With_WrongPassword_Returns401()
     {
         var client = _factory.CreateClient();

--- a/Backend/SBay.Backend.Tests/Authentication/AuthControllerTest.cs
+++ b/Backend/SBay.Backend.Tests/Authentication/AuthControllerTest.cs
@@ -147,6 +147,31 @@ public class AuthControllerTests : IClassFixture<TestWebAppFactory>
     }
 
     [Fact]
+    public async Task Logout_RevokesRefreshToken()
+    {
+        var client = _factory.CreateClient();
+        var email = $"{Guid.NewGuid():N}@example.com";
+        var pwd = "Password1!";
+
+        var registration = await client.PostAsJsonAsync("/api/auth/register", new RegisterRequest(email, pwd, "Logout"));
+        registration.EnsureSuccessStatusCode();
+        var verificationToken = _factory.Services.GetRequiredService<TestEmailSender>().GetLatestVerificationToken(email);
+        var verify = await client.PostAsJsonAsync("/api/auth/verify-email", new { token = verificationToken });
+        verify.EnsureSuccessStatusCode();
+
+        var login = await client.PostAsJsonAsync("/api/auth/login", new LoginRequest(email, pwd));
+        login.EnsureSuccessStatusCode();
+        var auth = await login.Content.ReadFromJsonAsync<AuthResponse>();
+        auth!.RefreshToken.Should().NotBeNullOrWhiteSpace();
+
+        var logout = await client.PostAsJsonAsync("/api/auth/logout", new { refreshToken = auth.RefreshToken });
+        logout.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var refresh = await client.PostAsJsonAsync("/api/auth/refresh", new { refreshToken = auth.RefreshToken });
+        refresh.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task Login_With_WrongPassword_Returns401()
     {
         var client = _factory.CreateClient();

--- a/Backend/SBay.Backend.Tests/Messaging/ChatServiceTests.cs
+++ b/Backend/SBay.Backend.Tests/Messaging/ChatServiceTests.cs
@@ -315,7 +315,7 @@ public sealed class ChatServiceTests
         notificationRepo.Setup(x => x.AddAsync(It.IsAny<UserNotification>(), It.IsAny<CancellationToken>()))
             .Callback<UserNotification, CancellationToken>((n, _) => notifications.Add(n))
             .Returns(Task.CompletedTask);
-        var now = new DateTime(2026, 5, 18, 10, 0, 0, DateTimeKind.Utc);
+        var now = DateTime.UtcNow;
         var svc = CreateService(db, seller, Clock(now), listingRepo.Object, notificationRepo.Object);
         var chat = await svc.OpenOrGetAsync(buyer, seller, listing.Id, default);
 

--- a/Backend/SBay.Backend.Tests/TestWebAppFactory.cs
+++ b/Backend/SBay.Backend.Tests/TestWebAppFactory.cs
@@ -35,6 +35,7 @@ public class TestWebAppFactory : WebApplicationFactory<Program>
                    ["Jwt:Audience"] = "SBayClients",
                    ["Jwt:Secret"] = "test_jwt_secret_32_bytes_minimum_value",
                    ["Jwt:ExpMinutes"] = "60",
+                   ["Jwt:RefreshTokenDays"] = "7",
                    ["RateLimits:Auth:PermitLimit"] = "1000",
                    ["RateLimits:Registration:PermitLimit"] = "1000",
                    ["RateLimits:Uploads:PermitLimit"] = "1000",

--- a/Backend/SBay.Backend/Program.cs
+++ b/Backend/SBay.Backend/Program.cs
@@ -49,7 +49,7 @@ if (!useEf)
     throw new InvalidOperationException("Firestore provider is not production-ready: refresh-token, notification, notification preference, push-token, reports, and user-block repositories are incomplete. Use Database:Provider=ef until those repositories are fully implemented.");
 }
 
-ConfigurationGuard.Validate(builder.Configuration);
+ConfigurationGuard.Validate(builder.Configuration, builder.Environment);
 ProductionConfigurationGuard.Validate(builder.Configuration, builder.Environment);
 
 if (useEf)
@@ -520,8 +520,10 @@ public partial class Program { }
 
 internal static class ConfigurationGuard
 {
-    public static void Validate(IConfiguration configuration)
+    public static void Validate(IConfiguration configuration, IWebHostEnvironment environment)
     {
+        if (environment.IsEnvironment("Testing")) return;
+
         var refreshTokenDays = configuration.GetValue<int?>("Jwt:RefreshTokenDays");
         if (refreshTokenDays is null)
             throw new InvalidOperationException("Jwt:RefreshTokenDays must be configured. Set JWT_REFRESH_TOKEN_DAYS in the environment.");

--- a/Backend/SBay.Backend/Program.cs
+++ b/Backend/SBay.Backend/Program.cs
@@ -49,6 +49,7 @@ if (!useEf)
     throw new InvalidOperationException("Firestore provider is not production-ready: refresh-token, notification, notification preference, push-token, reports, and user-block repositories are incomplete. Use Database:Provider=ef until those repositories are fully implemented.");
 }
 
+ConfigurationGuard.Validate(builder.Configuration);
 ProductionConfigurationGuard.Validate(builder.Configuration, builder.Environment);
 
 if (useEf)
@@ -516,6 +517,18 @@ else
 app.Run();
 
 public partial class Program { }
+
+internal static class ConfigurationGuard
+{
+    public static void Validate(IConfiguration configuration)
+    {
+        var refreshTokenDays = configuration.GetValue<int?>("Jwt:RefreshTokenDays");
+        if (refreshTokenDays is null)
+            throw new InvalidOperationException("Jwt:RefreshTokenDays must be configured. Set JWT_REFRESH_TOKEN_DAYS in the environment.");
+        if (refreshTokenDays is < 1 or > 365)
+            throw new InvalidOperationException("Jwt:RefreshTokenDays must be between 1 and 365.");
+    }
+}
 
 internal static class ProductionConfigurationGuard
 {

--- a/Backend/SBay.Backend/src/APIs/Controllers/AuthController.cs
+++ b/Backend/SBay.Backend/src/APIs/Controllers/AuthController.cs
@@ -404,9 +404,12 @@ public async Task<IActionResult> VerifyEmail([FromBody] VerifyEmailRequest reque
         if (result == PasswordVerificationResult.Failed)
             return Unauthorized(_l["Auth_InvalidCurrentPassword"].Value);
 
+        await using var tx = await _uow.BeginTransactionAsync(ct);
         user.PasswordHash = _hasher.HashPassword(user, req.NewPassword);
         await _users.UpdateAsync(user, ct);
+        await _refreshTokens.RevokeAllForUserAsync(user.Id, DateTimeOffset.UtcNow, ct);
         await _uow.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
 
         return Ok();
     }

--- a/Backend/SBay.Backend/src/APIs/Controllers/AuthController.cs
+++ b/Backend/SBay.Backend/src/APIs/Controllers/AuthController.cs
@@ -448,16 +448,16 @@ public async Task<IActionResult> VerifyEmail([FromBody] VerifyEmailRequest reque
 
     private (string Token, RefreshToken Entity) CreateRefreshToken(Guid userId)
     {
+        // Refresh tokens are opaque random secrets; only their hash is stored.
         var raw = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
         var now = DateTimeOffset.UtcNow;
-        var days = _config.GetValue<int?>("Jwt:RefreshTokenDays") ?? 30;
         var entity = new RefreshToken
         {
             Id = Guid.NewGuid(),
             UserId = userId,
             TokenHash = HashRefreshToken(raw),
             CreatedAt = now,
-            ExpiresAt = now.AddDays(Math.Clamp(days, 1, 365)),
+            ExpiresAt = now.AddDays(_jwt.RefreshTokenDays),
             DeviceId = Request.Headers.TryGetValue("X-Device-Id", out var deviceId) ? NormalizeHeaderValue(deviceId.ToString(), 128) : null,
             UserAgent = NormalizeHeaderValue(Request.Headers.UserAgent.ToString(), 512)
         };

--- a/Backend/SBay.Backend/src/Authentication/JwtOptions.cs
+++ b/Backend/SBay.Backend/src/Authentication/JwtOptions.cs
@@ -6,4 +6,5 @@ public sealed class JwtOptions
     public string Audience { get; set; } = "SBayClients";
     public string Secret { get; set; } = "REPLACE_ME_WITH_A_LONG_RANDOM_SECRET";
     public int ExpMinutes { get; set; } = 60;
+    public int RefreshTokenDays { get; set; }
 }

--- a/Frontend/web/src/__tests__/auth-session.test.ts
+++ b/Frontend/web/src/__tests__/auth-session.test.ts
@@ -1,0 +1,100 @@
+import axios from 'axios';
+import {
+  clearAuthSession,
+  refreshStoredAuthSession,
+  resetAuthSessionRefreshForTests,
+  revokeStoredRefreshToken,
+  storeAuthSession,
+} from '@/lib/auth-session';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const post = mockedAxios.post as jest.Mock;
+
+describe('web auth session storage', () => {
+  beforeEach(() => {
+    resetAuthSessionRefreshForTests();
+    post.mockReset();
+    (localStorage.getItem as jest.Mock).mockReset();
+    (localStorage.setItem as jest.Mock).mockReset();
+    (localStorage.removeItem as jest.Mock).mockReset();
+  });
+
+  it('stores access and refresh tokens together', () => {
+    storeAuthSession({ token: 'access-token', refreshToken: 'refresh-token' });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith('token', 'access-token');
+    expect(localStorage.setItem).toHaveBeenCalledWith('refreshToken', 'refresh-token');
+  });
+
+  it('removes stale refresh tokens when storing an access-token-only session', () => {
+    storeAuthSession({ token: 'access-token', refreshToken: null });
+
+    expect(localStorage.setItem).toHaveBeenCalledWith('token', 'access-token');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('refreshToken');
+  });
+
+  it('clears both stored tokens', () => {
+    clearAuthSession();
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('refreshToken');
+  });
+
+  it('rotates refresh tokens with one in-flight request for concurrent callers', async () => {
+    (localStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === 'refreshToken' ? 'old-refresh-token' : null,
+    );
+    post.mockResolvedValueOnce({
+      data: {
+        token: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+      },
+    });
+
+    const [first, second] = await Promise.all([
+      refreshStoredAuthSession(),
+      refreshStoredAuthSession(),
+    ]);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith(
+      '/api/auth/refresh',
+      { refreshToken: 'old-refresh-token' },
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expect(first).toEqual({ token: 'new-access-token', refreshToken: 'new-refresh-token' });
+    expect(second).toEqual(first);
+    expect(localStorage.setItem).toHaveBeenCalledWith('token', 'new-access-token');
+    expect(localStorage.setItem).toHaveBeenCalledWith('refreshToken', 'new-refresh-token');
+  });
+
+  it('does not refresh when no refresh token is stored', async () => {
+    (localStorage.getItem as jest.Mock).mockReturnValue(null);
+
+    await expect(refreshStoredAuthSession()).resolves.toBeNull();
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('sends the stored refresh token when revoking the session', async () => {
+    (localStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === 'refreshToken' ? 'refresh-token' : null,
+    );
+    post.mockResolvedValueOnce({ data: undefined });
+
+    await revokeStoredRefreshToken();
+
+    expect(post).toHaveBeenCalledWith(
+      '/api/auth/logout',
+      { refreshToken: 'refresh-token' },
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+});

--- a/Frontend/web/src/components/Header.tsx
+++ b/Frontend/web/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { Heart, Menu, MessageCircle, Package, User, X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'next-i18next';
+import { logout as revokeSession } from '@/lib/api/auth';
 import { useAuthStore } from '@/lib/store';
 import { config } from '@/lib/config';
 import LanguageToggle from './LanguageToggle';
@@ -25,11 +26,14 @@ export default function Header() {
   const isAdmin = user?.role === 'admin';
   const detached = scrolled || mobileMenuOpen;
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await revokeSession().catch((error) => {
+      console.error('Error revoking session:', error);
+    });
     logout();
     setUserMenuOpen(false);
     setMobileMenuOpen(false);
-    router.push('/');
+    void router.push('/');
   };
 
   const navLinkClass = (href: string) =>

--- a/Frontend/web/src/lib/api.ts
+++ b/Frontend/web/src/lib/api.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import config from './config';
+import {
+  clearAuthSession,
+  getStoredAccessToken,
+  refreshStoredAuthSession
+} from './auth-session';
 
 interface RetryableRequestConfig extends InternalAxiosRequestConfig {
   _retry?: boolean;
@@ -8,7 +13,7 @@ interface RetryableRequestConfig extends InternalAxiosRequestConfig {
 const api = axios.create({
   baseURL: config.apiUrl,
   timeout: config.apiTimeout,
-  headers: { 
+  headers: {
     'Content-Type': 'application/json',
   },
 });
@@ -33,14 +38,14 @@ if (config.enableLogging) {
     console.log(`[API] ${config.method?.toUpperCase()} ${config.url}`);
     return config;
   });
-  
+
   api.interceptors.response.use(
     (response) => {
-      console.log(`[API] ✓ ${response.config.method?.toUpperCase()} ${response.config.url}`);
+      console.log(`[API] OK ${response.config.method?.toUpperCase()} ${response.config.url}`);
       return response;
     },
     (error) => {
-      console.error(`[API] ✗ ${error.config?.method?.toUpperCase()} ${error.config?.url}`, error.message);
+      console.error(`[API] ERROR ${error.config?.method?.toUpperCase()} ${error.config?.url}`, error.message);
       return Promise.reject(error);
     }
   );
@@ -49,7 +54,7 @@ if (config.enableLogging) {
 if (typeof window !== 'undefined') {
   api.interceptors.request.use(
     (config) => {
-      const token = localStorage.getItem('token');
+      const token = getStoredAccessToken();
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
       }
@@ -74,35 +79,24 @@ if (typeof window !== 'undefined') {
       // Handle 401 Unauthorized - Token refresh
       if (error.response?.status === 401 && !originalRequest._retry) {
         originalRequest._retry = true;
-        const refreshToken = localStorage.getItem('refreshToken');
 
-        if (refreshToken) {
-          try {
-            const response = await axios.post(`${config.apiUrl}/auth/refresh`, { refreshToken });
-            const { token, refreshToken: nextRefreshToken } = response.data;
-
-            localStorage.setItem('token', token);
-            if (nextRefreshToken) {
-              localStorage.setItem('refreshToken', nextRefreshToken);
-            }
-            originalRequest.headers.Authorization = `Bearer ${token}`;
-            
+        try {
+          const session = await refreshStoredAuthSession();
+          if (session) {
+            originalRequest.headers.Authorization = `Bearer ${session.token}`;
             return api.request(originalRequest);
-          } catch (refreshError) {
-            // Refresh failed - logout
-            localStorage.removeItem('token');
-            localStorage.removeItem('refreshToken');
-            if (typeof window !== 'undefined' && !window.location.pathname.includes('/auth')) {
-              window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
-            }
-            return Promise.reject(refreshError);
           }
-        } else {
-          // No refresh token - logout
-          localStorage.removeItem('token');
+        } catch (refreshError) {
+          clearAuthSession();
           if (typeof window !== 'undefined' && !window.location.pathname.includes('/auth')) {
-            window.location.href = '/auth/login';
+            window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
           }
+          return Promise.reject(refreshError);
+        }
+
+        clearAuthSession();
+        if (typeof window !== 'undefined' && !window.location.pathname.includes('/auth')) {
+          window.location.href = '/auth/login';
         }
       }
 

--- a/Frontend/web/src/lib/api.ts
+++ b/Frontend/web/src/lib/api.ts
@@ -89,14 +89,14 @@ if (typeof window !== 'undefined') {
         } catch (refreshError) {
           clearAuthSession();
           if (typeof window !== 'undefined' && !window.location.pathname.includes('/auth')) {
-            window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+            window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname + window.location.search);
           }
           return Promise.reject(refreshError);
         }
 
         clearAuthSession();
         if (typeof window !== 'undefined' && !window.location.pathname.includes('/auth')) {
-          window.location.href = '/auth/login';
+          window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname + window.location.search);
         }
       }
 

--- a/Frontend/web/src/lib/api/auth.ts
+++ b/Frontend/web/src/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import { api } from '../api';
+import { revokeStoredRefreshToken } from '../auth-session';
 import type { UserLogin, UserRegistration } from '@sbay/shared';
 import { toUser, type BackendUserDto } from './transforms';
 
@@ -42,8 +43,7 @@ export const requestEmailVerification = async (): Promise<void> => {
  * Logout
  */
 export const logout = async () => {
-  const response = await api.post('/auth/logout');
-  return response.data;
+  await revokeStoredRefreshToken();
 };
 
 /**

--- a/Frontend/web/src/lib/api/recommendations.ts
+++ b/Frontend/web/src/lib/api/recommendations.ts
@@ -1,4 +1,5 @@
 import { api } from '../api';
+import { getStoredAccessToken } from '../auth-session';
 import type { Product } from '@sbay/shared';
 
 export type InteractionType = 'view' | 'category_click' | 'favorite' | 'purchase';
@@ -14,11 +15,11 @@ const topLevelCategory = (categoryPath?: string): string =>
 export const trackInteraction = async (category: string, type: InteractionType): Promise<void> => {
   const slug = topLevelCategory(category);
   if (!slug) return;
-  if (typeof window !== 'undefined' && !localStorage.getItem('token')) return;
+  if (typeof window !== 'undefined' && !getStoredAccessToken()) return;
   try {
     await api.post('/recommendations/track', { category: slug, type });
   } catch {
-    // ignore — tracking is best-effort
+    // ignore: tracking is best-effort
   }
 };
 
@@ -27,7 +28,7 @@ export const trackInteraction = async (category: string, type: InteractionType):
  * no interest data yet or is not logged in.
  */
 export const getRecommendedListings = async (pageSize = 12): Promise<Product[]> => {
-  if (typeof window !== 'undefined' && !localStorage.getItem('token')) return [];
+  if (typeof window !== 'undefined' && !getStoredAccessToken()) return [];
   try {
     const response = await api.get<Product[]>('/recommendations/listings', {
       params: { pageSize },

--- a/Frontend/web/src/lib/auth-session.ts
+++ b/Frontend/web/src/lib/auth-session.ts
@@ -1,0 +1,75 @@
+import axios from 'axios';
+import config from './config';
+
+type AuthSession = {
+  token: string;
+  refreshToken?: string | null;
+};
+
+let inflightRefresh: Promise<AuthSession> | null = null;
+
+export function getStoredAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('token');
+}
+
+function getStoredRefreshToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('refreshToken');
+}
+
+export function storeAuthSession(session: AuthSession): void {
+  if (typeof window === 'undefined') return;
+
+  localStorage.setItem('token', session.token);
+  if (session.refreshToken) {
+    localStorage.setItem('refreshToken', session.refreshToken);
+  } else {
+    localStorage.removeItem('refreshToken');
+  }
+}
+
+export function clearAuthSession(): void {
+  if (typeof window === 'undefined') return;
+
+  localStorage.removeItem('token');
+  localStorage.removeItem('refreshToken');
+}
+
+export async function refreshStoredAuthSession(): Promise<AuthSession | null> {
+  if (inflightRefresh) return inflightRefresh;
+
+  const refreshToken = getStoredRefreshToken();
+  if (!refreshToken) return null;
+
+  inflightRefresh = axios
+    .post<AuthSession>(
+      `${config.apiUrl}/auth/refresh`,
+      { refreshToken },
+      { timeout: config.apiTimeout },
+    )
+    .then((response) => {
+      storeAuthSession(response.data);
+      return response.data;
+    })
+    .finally(() => {
+      inflightRefresh = null;
+    });
+
+  return inflightRefresh;
+}
+
+export async function revokeStoredRefreshToken(): Promise<void> {
+  const refreshToken = getStoredRefreshToken();
+  if (!refreshToken) return;
+
+  await axios.post(
+    `${config.apiUrl}/auth/logout`,
+    { refreshToken },
+    { timeout: config.apiTimeout },
+  );
+}
+
+export function resetAuthSessionRefreshForTests(): void {
+  inflightRefresh = null;
+}

--- a/Frontend/web/src/lib/realtime/chat.ts
+++ b/Frontend/web/src/lib/realtime/chat.ts
@@ -6,6 +6,7 @@ import {
 } from '@microsoft/signalr';
 
 import config from '@/lib/config';
+import { getStoredAccessToken } from '@/lib/auth-session';
 
 export type RealtimeMessage = {
   id: string;
@@ -120,7 +121,7 @@ export async function createChatConnection(): Promise<HubConnection> {
   return new HubConnectionBuilder()
     .withUrl(resolveHubUrl(), {
       transport: HttpTransportType.WebSockets,
-      accessTokenFactory: () => localStorage.getItem('token') ?? '',
+      accessTokenFactory: () => getStoredAccessToken() ?? '',
     })
     .withAutomaticReconnect()
     .configureLogging(LogLevel.Warning)

--- a/Frontend/web/src/lib/store.ts
+++ b/Frontend/web/src/lib/store.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { User } from '@sbay/shared';
+import {
+  clearAuthSession,
+  getStoredAccessToken,
+  storeAuthSession
+} from './auth-session';
 
 interface AuthState {
   user: User | null;
@@ -41,21 +46,11 @@ export const useAuthStore = create<AuthState>()(
       isAuthenticated: false,
       hasHydrated: false,
       login: (user, token, refreshToken) => {
-        // Store in both localStorage (for API interceptor) and Zustand (for React state)
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('token', token);
-          if (refreshToken) {
-            localStorage.setItem('refreshToken', refreshToken);
-          }
-        }
+        storeAuthSession({ token, refreshToken });
         set({ user, token, isAuthenticated: true });
       },
       logout: () => {
-        // Clear both storage locations
-        if (typeof window !== 'undefined') {
-          localStorage.removeItem('token');
-          localStorage.removeItem('refreshToken');
-        }
+        clearAuthSession();
         set({ user: null, token: null, isAuthenticated: false });
       },
       setUser: (user) => {
@@ -75,7 +70,7 @@ export const useAuthStore = create<AuthState>()(
       // Rehydrate token from localStorage on load
       onRehydrateStorage: () => (state) => {
         if (state && typeof window !== 'undefined') {
-          const token = localStorage.getItem('token');
+          const token = getStoredAccessToken();
           if (token) {
             state.token = token;
             state.isAuthenticated = true;

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ For local development, set at minimum:
 - `Cors__AllowedOrigins__0` for the frontend origin
 - S3 storage settings if `Storage__Provider=s3`
 
+## Authentication Security
+
+`JWT_REFRESH_TOKEN_DAYS=180` is the sample default so web and mobile users can stay signed in. The backend requires `Jwt:RefreshTokenDays` at startup and rejects values outside `1..365`.
+
+Refresh tokens are opaque random secrets, stored only as hashes in PostgreSQL. They rotate on refresh and are revoked on logout, password reset, password change, account deactivation/deletion, and admin role/status changes.
+
+Each refresh token records the request user agent and optional `X-Device-Id` metadata. Device binding and anomaly detection are not enforced yet; deployments that need stronger long-lived-session controls should add those checks or lower `JWT_REFRESH_TOKEN_DAYS`.
+
 ## Common Commands
 
 Frontend checks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,7 +50,7 @@ services:
       Jwt__Audience: ${JWT_AUDIENCE:-SBayClients}
       Jwt__Secret: ${JWT_SECRET}
       Jwt__ExpMinutes: ${JWT_EXP_MINUTES:-60}
-      Jwt__RefreshTokenDays: ${JWT_REFRESH_TOKEN_DAYS:-30}
+      Jwt__RefreshTokenDays: "${JWT_REFRESH_TOKEN_DAYS:?Set JWT_REFRESH_TOKEN_DAYS in .env}"
       Redis__Host: redis
       Redis__Port: 6379
       App__PublicBaseUrl: ${APP_PUBLIC_BASE_URL:-https://api.syrian-bay.com}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,7 +50,7 @@ services:
       Jwt__Audience: ${JWT_AUDIENCE:-SBayClients}
       Jwt__Secret: ${JWT_SECRET}
       Jwt__ExpMinutes: ${JWT_EXP_MINUTES:-60}
-      Jwt__RefreshTokenDays: "${JWT_REFRESH_TOKEN_DAYS:?Set JWT_REFRESH_TOKEN_DAYS in .env}"
+      Jwt__RefreshTokenDays: ${JWT_REFRESH_TOKEN_DAYS}
       Redis__Host: redis
       Redis__Port: 6379
       App__PublicBaseUrl: ${APP_PUBLIC_BASE_URL:-https://api.syrian-bay.com}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       Jwt__Audience: ${JWT_AUDIENCE:-SBayClients}
       Jwt__Secret: ${JWT_SECRET:-dev_only_change_me_32_bytes_minimum_value}
       Jwt__ExpMinutes: ${JWT_EXP_MINUTES:-60}
-      Jwt__RefreshTokenDays: "${JWT_REFRESH_TOKEN_DAYS:?Set JWT_REFRESH_TOKEN_DAYS in .env}"
+      Jwt__RefreshTokenDays: ${JWT_REFRESH_TOKEN_DAYS}
       Redis__Host: redis
       Redis__Port: 6379
       App__PublicBaseUrl: ${APP_PUBLIC_BASE_URL:-http://localhost:8080}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       Jwt__Audience: ${JWT_AUDIENCE:-SBayClients}
       Jwt__Secret: ${JWT_SECRET:-dev_only_change_me_32_bytes_minimum_value}
       Jwt__ExpMinutes: ${JWT_EXP_MINUTES:-60}
-      Jwt__RefreshTokenDays: ${JWT_REFRESH_TOKEN_DAYS:-30}
+      Jwt__RefreshTokenDays: "${JWT_REFRESH_TOKEN_DAYS:?Set JWT_REFRESH_TOKEN_DAYS in .env}"
       Redis__Host: redis
       Redis__Port: 6379
       App__PublicBaseUrl: ${APP_PUBLIC_BASE_URL:-http://localhost:8080}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logout now properly revokes refresh tokens, preventing reuse of invalidated tokens after sign-out.

* **Improvements**
  * Extended refresh token validity period from 30 to 180 days.
  * Enhanced frontend token session management for improved reliability and security.

* **Chores**
  * Updated JWT configuration validation and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->